### PR TITLE
feat(frontend): implement theme mode and logout button

### DIFF
--- a/apps/frontend/lib/app.dart
+++ b/apps/frontend/lib/app.dart
@@ -6,6 +6,7 @@ import 'core/router/app_router.dart';
 import 'core/theme/app_theme.dart';
 import 'features/auth/presentation/bloc/auth_bloc.dart';
 import 'features/settings/presentation/cubit/language_cubit.dart';
+import 'features/settings/presentation/cubit/theme_cubit.dart';
 import 'core/di/injection.dart';
 
 class ChatApp extends StatelessWidget {
@@ -17,21 +18,26 @@ class ChatApp extends StatelessWidget {
       providers: [
         BlocProvider(create: (_) => getIt<AuthBloc>()),
         BlocProvider(create: (_) => getIt<LanguageCubit>()),
+        BlocProvider(create: (_) => getIt<ThemeCubit>()),
       ],
       child: BlocBuilder<LanguageCubit, Locale>(
         builder: (context, locale) {
-          return MaterialApp.router(
-            title: 'ChatDP',
-            theme: AppTheme.lightTheme,
-            darkTheme: AppTheme.darkTheme,
-            themeMode: ThemeMode.system,
-            locale: locale,
-            routerConfig: AppRouter.router,
-            debugShowCheckedModeBanner: false,
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            onGenerateTitle: (context) =>
-                AppLocalizations.of(context)!.appTitle,
+          return BlocBuilder<ThemeCubit, ThemeMode>(
+            builder: (context, themeMode) {
+              return MaterialApp.router(
+                title: 'ChatDP',
+                theme: AppTheme.lightTheme,
+                darkTheme: AppTheme.darkTheme,
+                themeMode: themeMode,
+                locale: locale,
+                routerConfig: AppRouter.router,
+                debugShowCheckedModeBanner: false,
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                onGenerateTitle: (context) =>
+                    AppLocalizations.of(context)!.appTitle,
+              );
+            },
           );
         },
       ),

--- a/apps/frontend/lib/core/di/injection.config.dart
+++ b/apps/frontend/lib/core/di/injection.config.dart
@@ -29,6 +29,7 @@ import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i674;
 import '../../features/settings/presentation/cubit/language_cubit.dart'
     as _i530;
+import '../../features/settings/presentation/cubit/theme_cubit.dart' as _i124;
 import '../network/auth_interceptor.dart' as _i908;
 import '../network/dio_client.dart' as _i667;
 import 'storage_module.dart' as _i371;
@@ -58,6 +59,9 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i530.LanguageCubit>(
       () => _i530.LanguageCubit(gh<_i674.SettingsRepository>()),
+    );
+    gh.factory<_i124.ThemeCubit>(
+      () => _i124.ThemeCubit(gh<_i674.SettingsRepository>()),
     );
     gh.lazySingleton<_i361.Dio>(
       () => networkModule.dio(gh<_i908.AuthInterceptor>()),

--- a/apps/frontend/lib/features/settings/data/datasources/settings_local_data_source.dart
+++ b/apps/frontend/lib/features/settings/data/datasources/settings_local_data_source.dart
@@ -4,6 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 abstract class SettingsLocalDataSource {
   Future<void> cacheLanguageCode(String languageCode);
   Future<String?> getCachedLanguageCode();
+  Future<void> cacheThemeMode(String themeMode);
+  Future<String?> getCachedThemeMode();
 }
 
 @LazySingleton(as: SettingsLocalDataSource)
@@ -13,6 +15,7 @@ class SettingsLocalDataSourceImpl implements SettingsLocalDataSource {
   SettingsLocalDataSourceImpl(this._sharedPreferences);
 
   static const _cachedLanguageCodeKey = 'CACHED_LANGUAGE_CODE';
+  static const _cachedThemeModeKey = 'CACHED_THEME_MODE';
 
   @override
   Future<void> cacheLanguageCode(String languageCode) {
@@ -22,5 +25,15 @@ class SettingsLocalDataSourceImpl implements SettingsLocalDataSource {
   @override
   Future<String?> getCachedLanguageCode() async {
     return _sharedPreferences.getString(_cachedLanguageCodeKey);
+  }
+
+  @override
+  Future<void> cacheThemeMode(String themeMode) {
+    return _sharedPreferences.setString(_cachedThemeModeKey, themeMode);
+  }
+
+  @override
+  Future<String?> getCachedThemeMode() async {
+    return _sharedPreferences.getString(_cachedThemeModeKey);
   }
 }

--- a/apps/frontend/lib/features/settings/data/repositories/settings_repository_impl.dart
+++ b/apps/frontend/lib/features/settings/data/repositories/settings_repository_impl.dart
@@ -14,4 +14,11 @@ class SettingsRepositoryImpl implements SettingsRepository {
   @override
   Future<void> setLanguage(String languageCode) =>
       _localDataSource.cacheLanguageCode(languageCode);
+
+  @override
+  Future<String?> getThemeMode() => _localDataSource.getCachedThemeMode();
+
+  @override
+  Future<void> setThemeMode(String themeMode) =>
+      _localDataSource.cacheThemeMode(themeMode);
 }

--- a/apps/frontend/lib/features/settings/domain/repositories/settings_repository.dart
+++ b/apps/frontend/lib/features/settings/domain/repositories/settings_repository.dart
@@ -1,4 +1,6 @@
 abstract class SettingsRepository {
   Future<void> setLanguage(String languageCode);
   Future<String?> getLanguage();
+  Future<void> setThemeMode(String themeMode);
+  Future<String?> getThemeMode();
 }

--- a/apps/frontend/lib/features/settings/presentation/cubit/theme_cubit.dart
+++ b/apps/frontend/lib/features/settings/presentation/cubit/theme_cubit.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import '../../domain/repositories/settings_repository.dart';
+
+@injectable
+class ThemeCubit extends Cubit<ThemeMode> {
+  final SettingsRepository _settingsRepository;
+
+  ThemeCubit(this._settingsRepository) : super(ThemeMode.system) {
+    _loadTheme();
+  }
+
+  Future<void> _loadTheme() async {
+    final themeName = await _settingsRepository.getThemeMode();
+    if (themeName != null) {
+      final mode = ThemeMode.values.firstWhere(
+        (e) => e.name == themeName,
+        orElse: () => ThemeMode.system,
+      );
+      emit(mode);
+    }
+  }
+
+  Future<void> changeTheme(ThemeMode mode) async {
+    await _settingsRepository.setThemeMode(mode.name);
+    emit(mode);
+  }
+}

--- a/apps/frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/apps/frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../cubit/language_cubit.dart';
+import '../cubit/theme_cubit.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
@@ -9,33 +10,97 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.navSettings)),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              l10n.selectLanguage,
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                context.read<LanguageCubit>().changeLanguage('en');
-              },
-              child: Text(l10n.english),
-            ),
-            const SizedBox(height: 10),
-            ElevatedButton(
-              onPressed: () {
-                context.read<LanguageCubit>().changeLanguage('vi');
-              },
-              child: Text(l10n.vietnamese),
-            ),
-          ],
+      appBar: AppBar(title: Text(l10n.navSettings), centerTitle: true),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          _buildSectionHeader(context, l10n.language),
+          _buildLanguageSelector(context, l10n),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Divider(),
+          ),
+          _buildSectionHeader(context, l10n.themeMode),
+          _buildThemeSelector(context, l10n),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      child: Text(
+        title.toUpperCase(),
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+          color: Theme.of(context).colorScheme.primary,
+          fontWeight: FontWeight.bold,
+          letterSpacing: 1.2,
         ),
       ),
+    );
+  }
+
+  Widget _buildLanguageSelector(BuildContext context, AppLocalizations l10n) {
+    return BlocBuilder<LanguageCubit, Locale>(
+      builder: (context, locale) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SegmentedButton<String>(
+            segments: [
+              ButtonSegment<String>(
+                value: 'en',
+                label: Text(l10n.english),
+                icon: const Icon(Icons.language),
+              ),
+              ButtonSegment<String>(
+                value: 'vi',
+                label: Text(l10n.vietnamese),
+                icon: const Icon(Icons.translate),
+              ),
+            ],
+            selected: {locale.languageCode},
+            onSelectionChanged: (Set<String> newSelection) {
+              context.read<LanguageCubit>().changeLanguage(newSelection.first);
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildThemeSelector(BuildContext context, AppLocalizations l10n) {
+    return BlocBuilder<ThemeCubit, ThemeMode>(
+      builder: (context, themeMode) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SegmentedButton<ThemeMode>(
+            segments: [
+              ButtonSegment<ThemeMode>(
+                value: ThemeMode.system,
+                label: Text(l10n.themeSystem),
+                icon: const Icon(Icons.brightness_auto),
+              ),
+              ButtonSegment<ThemeMode>(
+                value: ThemeMode.light,
+                label: Text(l10n.themeLight),
+                icon: const Icon(Icons.light_mode),
+              ),
+              ButtonSegment<ThemeMode>(
+                value: ThemeMode.dark,
+                label: Text(l10n.themeDark),
+                icon: const Icon(Icons.dark_mode),
+              ),
+            ],
+            selected: {themeMode},
+            onSelectionChanged: (Set<ThemeMode> newSelection) {
+              context.read<ThemeCubit>().changeTheme(newSelection.first);
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/apps/frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/apps/frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../cubit/language_cubit.dart';
 import '../cubit/theme_cubit.dart';
+import '../../../auth/presentation/bloc/auth_bloc.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
@@ -24,6 +25,28 @@ class SettingsPage extends StatelessWidget {
           ),
           _buildSectionHeader(context, l10n.themeMode),
           _buildThemeSelector(context, l10n),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Divider(),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: OutlinedButton.icon(
+              onPressed: () {
+                context.read<AuthBloc>().add(const AuthLogoutRequested());
+              },
+              icon: const Icon(Icons.logout),
+              label: Text(l10n.logout),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Colors.redAccent,
+                side: const BorderSide(color: Colors.redAccent),
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/apps/frontend/lib/features/shell/presentation/pages/app_shell_page.dart
+++ b/apps/frontend/lib/features/shell/presentation/pages/app_shell_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:frontend/l10n/app_localizations.dart';
+import '../../../auth/presentation/bloc/auth_bloc.dart';
+import '../../../../core/router/app_routes.dart';
 
 class AppShellPage extends StatelessWidget {
   const AppShellPage({super.key, required this.navigationShell});
@@ -10,26 +13,33 @@ class AppShellPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    return Scaffold(
-      body: navigationShell,
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: navigationShell.currentIndex,
-        items: [
-          BottomNavigationBarItem(
-            icon: const Icon(Icons.chat),
-            label: l10n.navChat,
-          ),
-          BottomNavigationBarItem(
-            icon: const Icon(Icons.settings),
-            label: l10n.navSettings,
-          ),
-        ],
-        onTap: (index) {
-          navigationShell.goBranch(
-            index,
-            initialLocation: index == navigationShell.currentIndex,
-          );
-        },
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is Unauthenticated) {
+          context.go(AppRoutes.login);
+        }
+      },
+      child: Scaffold(
+        body: navigationShell,
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: navigationShell.currentIndex,
+          items: [
+            BottomNavigationBarItem(
+              icon: const Icon(Icons.chat),
+              label: l10n.navChat,
+            ),
+            BottomNavigationBarItem(
+              icon: const Icon(Icons.settings),
+              label: l10n.navSettings,
+            ),
+          ],
+          onTap: (index) {
+            navigationShell.goBranch(
+              index,
+              initialLocation: index == navigationShell.currentIndex,
+            );
+          },
+        ),
       ),
     );
   }

--- a/apps/frontend/lib/l10n/app_en.arb
+++ b/apps/frontend/lib/l10n/app_en.arb
@@ -62,5 +62,6 @@
   "themeMode": "Theme Mode",
   "themeLight": "Light",
   "themeDark": "Dark",
-  "themeSystem": "System (default)"
+  "themeSystem": "System (default)",
+  "logout": "Logout"
 }

--- a/apps/frontend/lib/l10n/app_en.arb
+++ b/apps/frontend/lib/l10n/app_en.arb
@@ -58,5 +58,9 @@
   "english": "English",
   "vietnamese": "Tiếng Việt",
   "invalidCredentials": "Incorrect email or password",
-  "emailAlreadyRegistered": "Email is already registered. Please sign in"
+  "emailAlreadyRegistered": "Email is already registered. Please sign in",
+  "themeMode": "Theme Mode",
+  "themeLight": "Light",
+  "themeDark": "Dark",
+  "themeSystem": "System (default)"
 }

--- a/apps/frontend/lib/l10n/app_localizations.dart
+++ b/apps/frontend/lib/l10n/app_localizations.dart
@@ -451,6 +451,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Email is already registered. Please sign in'**
   String get emailAlreadyRegistered;
+
+  /// No description provided for @themeMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme Mode'**
+  String get themeMode;
+
+  /// No description provided for @themeLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeLight;
+
+  /// No description provided for @themeDark.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeDark;
+
+  /// No description provided for @themeSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'System (default)'**
+  String get themeSystem;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/frontend/lib/l10n/app_localizations.dart
+++ b/apps/frontend/lib/l10n/app_localizations.dart
@@ -475,6 +475,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'System (default)'**
   String get themeSystem;
+
+  /// No description provided for @logout.
+  ///
+  /// In en, this message translates to:
+  /// **'Logout'**
+  String get logout;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/frontend/lib/l10n/app_localizations_en.dart
+++ b/apps/frontend/lib/l10n/app_localizations_en.dart
@@ -206,4 +206,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get themeSystem => 'System (default)';
+
+  @override
+  String get logout => 'Logout';
 }

--- a/apps/frontend/lib/l10n/app_localizations_en.dart
+++ b/apps/frontend/lib/l10n/app_localizations_en.dart
@@ -194,4 +194,16 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get emailAlreadyRegistered =>
       'Email is already registered. Please sign in';
+
+  @override
+  String get themeMode => 'Theme Mode';
+
+  @override
+  String get themeLight => 'Light';
+
+  @override
+  String get themeDark => 'Dark';
+
+  @override
+  String get themeSystem => 'System (default)';
 }

--- a/apps/frontend/lib/l10n/app_localizations_vi.dart
+++ b/apps/frontend/lib/l10n/app_localizations_vi.dart
@@ -195,4 +195,16 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get emailAlreadyRegistered =>
       'Email đã được đăng ký. Vui lòng đăng nhập';
+
+  @override
+  String get themeMode => 'Chế độ giao diện';
+
+  @override
+  String get themeLight => 'Sáng';
+
+  @override
+  String get themeDark => 'Tối';
+
+  @override
+  String get themeSystem => 'Hệ thống (mặc định)';
 }

--- a/apps/frontend/lib/l10n/app_localizations_vi.dart
+++ b/apps/frontend/lib/l10n/app_localizations_vi.dart
@@ -207,4 +207,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get themeSystem => 'Hệ thống (mặc định)';
+
+  @override
+  String get logout => 'Đăng xuất';
 }

--- a/apps/frontend/lib/l10n/app_vi.arb
+++ b/apps/frontend/lib/l10n/app_vi.arb
@@ -62,5 +62,6 @@
   "themeMode": "Chế độ giao diện",
   "themeLight": "Sáng",
   "themeDark": "Tối",
-  "themeSystem": "Hệ thống (mặc định)"
+  "themeSystem": "Hệ thống (mặc định)",
+  "logout": "Đăng xuất"
 }

--- a/apps/frontend/lib/l10n/app_vi.arb
+++ b/apps/frontend/lib/l10n/app_vi.arb
@@ -58,5 +58,9 @@
   "english": "Tiếng Anh",
   "vietnamese": "Tiếng Việt",
   "invalidCredentials": "Email hoặc mật khẩu không chính xác",
-  "emailAlreadyRegistered": "Email đã được đăng ký. Vui lòng đăng nhập"
+  "emailAlreadyRegistered": "Email đã được đăng ký. Vui lòng đăng nhập",
+  "themeMode": "Chế độ giao diện",
+  "themeLight": "Sáng",
+  "themeDark": "Tối",
+  "themeSystem": "Hệ thống (mặc định)"
 }

--- a/apps/frontend/test/features/auth/data/datasources/auth_remote_data_source_test.dart
+++ b/apps/frontend/test/features/auth/data/datasources/auth_remote_data_source_test.dart
@@ -146,9 +146,7 @@ void main() {
         // 2. Mock getProfile call
         final profileResponse = MockResponse();
         when(() => profileResponse.data).thenReturn(tUserModel.toJson());
-        when(
-          () => mockDio.get('/users/me'),
-        ).thenAnswer((_) async => profileResponse);
+        when(() => mockDio.get('/me')).thenAnswer((_) async => profileResponse);
 
         // Act
         final result = await dataSource.verifyEmail(tEmail, tOtp);
@@ -162,7 +160,7 @@ void main() {
             data: {'email': tEmail, 'otp': tOtp},
           ),
         ).called(1);
-        verify(() => mockDio.get('/users/me')).called(1);
+        verify(() => mockDio.get('/me')).called(1);
       },
     );
   });


### PR DESCRIPTION
## Summary
This PR implements theme mode switching (Light/Dark/System) and adds a logout button to the Settings page.

## Changes
- ✨ Added theme mode support with persistence to SharedPreferences
- 🎨 Created ThemeCubit for theme state management
- 🔄 Integrated ThemeCubit into ChatApp for dynamic theme switching
- 🎨 Redesigned SettingsPage with modern SegmentedButton UI
- 🚪 Added Logout button in Settings with proper authentication flow
- 🌐 Added localization strings for theme options and logout (EN/VI)
- �� Added BlocListener to AppShellPage for logout redirection

## Testing
- [x] Theme switching works correctly (Light/Dark/System)
- [x] Theme preference persists across app restarts
- [x] Logout button redirects to login page
- [x] Localization works for both English and Vietnamese